### PR TITLE
Add extern for the Location service, allow chaining of methods for Scope

### DIFF
--- a/src/angular/provider/Location.hx
+++ b/src/angular/provider/Location.hx
@@ -1,0 +1,6 @@
+
+package angular.provider;
+
+@:injectionName("$location")
+extern class Location {
+}

--- a/src/angular/service/Scope.hx
+++ b/src/angular/service/Scope.hx
@@ -70,9 +70,10 @@ extern class Scope
 		return Reflect.field(this, field);
 	}
 
-	public inline function set (field:String, val:Dynamic):Void
+	public inline function set (field:String, val:Dynamic):Scope
 	{
 		Reflect.setField(this, field, val);
+    return this;
 	}
 
 	public inline function safeApply(f:Void->Void):Void


### PR DESCRIPTION
Hey there @frabbit 

In a sample app for Angular 1.x and Haxe I've been working on, I needed the `$location` service, and couldn't find it in the externs, so I added it here.

I also added the ability to chain method calls for scope, like this:
<img width="400" alt="screenshot 2016-03-17 12 49 02" src="https://cloud.githubusercontent.com/assets/81248/13857238/a50cc526-ec3e-11e5-93d1-48ff9eda9054.png">

Let me know what you think!
